### PR TITLE
Make it output sane visual studio project names, and use VS2019.

### DIFF
--- a/templates/solution.sln
+++ b/templates/solution.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.452
 MinimumVisualStudioVersion = 10.0.40219.1
 {projects}
 Global

--- a/templates/vcxproj.xml
+++ b/templates/vcxproj.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup Label="ProjectConfigurations">{project_configs}
   </ItemGroup>
@@ -7,8 +7,8 @@
 {config_properties}
 
   <PropertyGroup Label="Globals">
-    <ProjectName>{target.label.absolute}</ProjectName>
-    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectName>{target.label.name}</ProjectName>
+    <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{target.guid}</ProjectGuid>
     <Keyword>MakeFileProj</Keyword>
     <UseHostCompilerIfAvailable>false</UseHostCompilerIfAvailable>
@@ -21,7 +21,7 @@
 
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Fastbuild'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
Using the absolute path for the project name results in some project not getting loaded by visual studio due to malformed XML.
And well... VS 2013 is a bit old by now...