### PR TITLE
Ensure the output directory exists even if a label contains slashes

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -427,8 +427,9 @@ def generate_projects(cfg):
             include_dirs_joined=info.include_dirs_joined(cfg, rel_paths))
         filters_content = _generate_project_filters(filters_template, cfg, info)
 
-        _makedirs(project_dir)
-        with open(os.path.join(project_dir, info.label.name+'.vcxproj'), 'w') as out:
+        path = os.path.join(project_dir, info.label.name+'.vcxproj')
+        _makedirs(os.path.dirname(path))
+        with open(path, 'w') as out:
             out.write(content)
         with open(os.path.join(project_dir, info.label.name+'.vcxproj.filters'), 'w') as out:
             out.write(filters_content)


### PR DESCRIPTION
I have a case where a label is of the form `directory/binary.exe`. For this, the directory
`{project_dir}/directory` needs to be created by `_makedirs()`.